### PR TITLE
Resuscitation on Aisle 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ By default, the StripeExecutor will be locked to the version of the API that the
 is tested against. If you want to change that you could declare your executor like so:
 
 ```scala
-implicit val e = new StripeExecutor("myapikey", apiVersion = "2014-12-22")
+implicit val e = new StripeExecutor("myapikey", apiVersion = "2016-03-07")
 ```
 
-That would lock your app to the 2014-12-22 version of the API regardless of what the version of the
+That would lock your app to the 2016-03-07 version of the API regardless of what the version of the
 library you're using wants. *Please be aware this could cause things to break.* If for some reason
 we're not pulling out data that you need from the JSON that Stripe sends us, you can get a copy of
 that represented as a Lift JValue by setting the `includeRaw` parameter on the executor to true.

--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,12 @@ version := "0.0.4-SNAPSHOT"
 
 organization := "me.frmr.stripe"
 
-scalaVersion := "2.11.4"
+scalaVersion := "2.11.8"
 
 resolvers += "Farmdawg Temp Forks" at "http://dl.bintray.com/farmdawgnation/temp-forks"
 
 libraryDependencies ++= {
-  val liftVersion = "2.6-RC1"
+  val liftVersion = "2.6.3"
   Seq(
     "net.liftweb"               %% "lift-common"          % liftVersion,
     "net.liftweb"               %% "lift-util"            % liftVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,9 @@ libraryDependencies ++= {
     "net.liftweb"               %% "lift-common"          % liftVersion,
     "net.liftweb"               %% "lift-util"            % liftVersion,
     "net.liftweb"               %% "lift-json"            % liftVersion,
-    "net.databinder.dispatch"   %% "dispatch-core"        % "0.11.2",
-    "net.databinder.dispatch"   %% "dispatch-lift-json"   % "0.11.2",
-    "org.scalatest"             %% "scalatest"            % "2.2.1"        % "test"
+    "net.databinder.dispatch"   %% "dispatch-core"        % "0.11.3",
+    "net.databinder.dispatch"   %% "dispatch-lift-json"   % "0.11.3",
+    "org.scalatest"             %% "scalatest"            % "2.2.6"        % "test"
   )
 }
 

--- a/src/main/scala/me/frmr/stripe/Account.scala
+++ b/src/main/scala/me/frmr/stripe/Account.scala
@@ -12,7 +12,6 @@ case class Account(
   id: String,
   chargesEnabled: Boolean,
   country: String,
-  currenciesSupported: List[String],
   defaultCurrency: String,
   detailsSubmitted: Boolean,
   transfersEnabled: Boolean,

--- a/src/main/scala/me/frmr/stripe/Customer.scala
+++ b/src/main/scala/me/frmr/stripe/Customer.scala
@@ -15,12 +15,12 @@ import dispatch._, Defaults._
 case class Customer(
   id: String,
   livemode: Boolean,
-  cards: CardList,
+  sources: CardList,
   created: Long,
   accountBalance: Long,
   currency: String,
   delinquent: Boolean,
-  defaultCard: Option[String],
+  defaultSource: Option[String],
   description: Option[String],
   discount: Option[Discount],
   email: Option[String],
@@ -63,7 +63,7 @@ object Customer extends Listable[CustomerList] with Gettable[Customer] with Dele
     id: String,
     accountBalance: Option[String] = None,
     card: Option[String] = None,
-    defaultCard: Option[String] = None,
+    defaultSource: Option[String] = None,
     coupon: Option[String] = None,
     description: Option[String] = None,
     email: Option[String] = None,
@@ -73,7 +73,7 @@ object Customer extends Listable[CustomerList] with Gettable[Customer] with Dele
       accountBalance.map(("account_balance", _)),
       card.map(("card", _)),
       coupon.map(("coupon", _)),
-      defaultCard.map(("default_card", _)),
+      defaultSource.map(("default_source", _)),
       description.map(("description", _)),
       email.map(("email", _))
     ).flatten.toMap ++ metadataProcessor(metadata)

--- a/src/main/scala/me/frmr/stripe/StripeExecutor.scala
+++ b/src/main/scala/me/frmr/stripe/StripeExecutor.scala
@@ -45,7 +45,7 @@ object AsStripeResponse extends (Response=>StripeResponse) {
 class StripeExecutor(
   apiKey: String,
   includeRaw: Boolean = false,
-  apiVersion: String = "2014-12-22"
+  apiVersion: String = "2016-03-07"
 ) {
   val httpExecutor = new Http()
   val baseReq = url("https://api.stripe.com/v1").secure.as(apiKey, "") <:< Map("Stripe-Version" -> apiVersion)

--- a/src/test/scala/me/frmr/stripe/AccountSpec.scala
+++ b/src/test/scala/me/frmr/stripe/AccountSpec.scala
@@ -16,22 +16,140 @@ class AccountSpec extends WordSpec with ShouldMatchers {
       val json = """
         {
           "id": "acct_1032D82eZvKYlo2C",
-          "email": "site@stripe.com",
-          "statement_descriptor": null,
-          "display_name": "Stripe.com",
-          "timezone": "US/Pacific",
-          "details_submitted": false,
-          "charges_enabled": false,
-          "transfers_enabled": false,
-          "currencies_supported": [
-            "usd",
-            "aed",
-            "afn"
-          ],
-          "default_currency": "usd",
-          "country": "US",
           "object": "account",
-          "business_name": "Stripe.com"
+          "business_logo": null,
+          "business_name": "Stripe.com",
+          "business_url": null,
+          "charges_enabled": false,
+          "country": "US",
+          "debit_negative_balances": true,
+          "decline_charge_on": {
+            "avs_failure": false,
+            "cvc_failure": false
+          },
+          "default_currency": "usd",
+          "details_submitted": false,
+          "display_name": "Stripe.com",
+          "email": "site@stripe.com",
+          "external_accounts": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/accounts/acct_1032D82eZvKYlo2C/external_accounts"
+          },
+          "legal_entity": {
+            "additional_owners": null,
+            "address": {
+              "city": null,
+              "country": "US",
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "address_kana": {
+              "city": null,
+              "country": "US",
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null,
+              "town": null
+            },
+            "address_kanji": {
+              "city": null,
+              "country": "US",
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null,
+              "town": null
+            },
+            "business_name": null,
+            "business_name_kana": null,
+            "business_name_kanji": null,
+            "business_tax_id_provided": false,
+            "dob": {
+              "day": null,
+              "month": null,
+              "year": null
+            },
+            "first_name": null,
+            "first_name_kana": null,
+            "first_name_kanji": null,
+            "gender": null,
+            "last_name": null,
+            "last_name_kana": null,
+            "last_name_kanji": null,
+            "maiden_name": null,
+            "personal_address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "personal_address_kana": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null,
+              "town": null
+            },
+            "personal_address_kanji": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null,
+              "town": null
+            },
+            "personal_id_number_provided": false,
+            "phone_number": null,
+            "ssn_last_4_provided": false,
+            "type": null,
+            "verification": {
+              "details": null,
+              "details_code": "failed_other",
+              "document": null,
+              "status": "unverified"
+            }
+          },
+          "managed": false,
+          "product_description": null,
+          "statement_descriptor": null,
+          "support_email": null,
+          "support_phone": null,
+          "timezone": "US/Pacific",
+          "tos_acceptance": {
+            "date": null,
+            "ip": null,
+            "user_agent": null
+          },
+          "transfer_schedule": {
+            "delay_days": 7,
+            "interval": "daily"
+          },
+          "transfers_enabled": false,
+          "verification": {
+            "disabled_reason": "fields_needed",
+            "due_by": null,
+            "fields_needed": [
+            "business_url",
+            "external_account",
+            "product_description",
+            "support_phone",
+            "tos_acceptance.date",
+            "tos_acceptance.ip"
+            ]
+          }
         }
       """
 
@@ -45,7 +163,6 @@ class AccountSpec extends WordSpec with ShouldMatchers {
       testAccount.detailsSubmitted should equal(false)
       testAccount.chargesEnabled should equal(false)
       testAccount.transfersEnabled should equal(false)
-      testAccount.currenciesSupported(0) should equal("usd")
       testAccount.defaultCurrency should equal("usd")
       testAccount.country should equal("US")
       testAccount.businessName should equal("Stripe.com")

--- a/src/test/scala/me/frmr/stripe/BalanceSpec.scala
+++ b/src/test/scala/me/frmr/stripe/BalanceSpec.scala
@@ -15,20 +15,30 @@ class BalanceSpec extends WordSpec with ShouldMatchers {
     "retrieve correct fields from Stripe's JSON" in {
       val exampleBalanceJson = """
         {
-          "pending": [
-            {
-              "amount": 4966640,
-              "currency": "usd"
-            }
-          ],
+          "object": "balance",
           "available": [
-            {
-              "amount": -2352,
-              "currency": "usd"
+          {
+            "currency": "usd",
+            "amount": -2352,
+            "source_types": {
+              "card": 8032622669,
+              "bank_account": 8509784,
+              "bitcoin_receiver": 1449199
             }
+          }
           ],
           "livemode": false,
-          "object": "balance"
+          "pending": [
+          {
+            "currency": "usd",
+            "amount": 4966640,
+            "source_types": {
+              "card": 746697673,
+              "bank_account": 0,
+              "bitcoin_receiver": 0
+            }
+          }
+          ]
         }
       """
 

--- a/src/test/scala/me/frmr/stripe/BalanceTransactionSpec.scala
+++ b/src/test/scala/me/frmr/stripe/BalanceTransactionSpec.scala
@@ -15,44 +15,53 @@ class BalanceTransactionSpec extends WordSpec with ShouldMatchers {
     "retrieve correct fields from Stripe's JSON" in {
       val exampleJson = """
         {
-          "id": "txn_15DRvX2eZvKYlo2CgxMQ25SQ",
+          "id": "txn_17bBwe2eZvKYlo2Cuwcyi9or",
           "object": "balance_transaction",
-          "amount": 500,
+          "amount": 400,
+          "available_on": 1455235200,
+          "created": 1454687788,
           "currency": "usd",
-          "net": 455,
-          "type": "charge",
-          "created": 1419476679,
-          "available_on": 1420070400,
-          "status": "pending",
-          "fee": 45,
+          "description": "Charge for test@example.com",
+          "fee": 42,
           "fee_details": [
-            {
-              "amount": 45,
-              "currency": "usd",
-              "type": "stripe_fee",
-              "description": "Stripe processing fees",
-              "application": null
-            }
+          {
+            "amount": 42,
+            "application": null,
+            "currency": "usd",
+            "description": "Stripe processing fees",
+            "type": "stripe_fee"
+          }
           ],
-          "source": "ch_15DRvX2eZvKYlo2CzgFB69s3",
-          "description": null
+          "net": 358,
+          "source": "ch_17bBwe2eZvKYlo2Crk3VGEG8",
+          "sourced_transfers": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/transfers?source_transaction=ch_17bBwe2eZvKYlo2Crk3VGEG8"
+          },
+          "status": "pending",
+          "type": "charge"
         }
       """
 
       val testBalanceTransaction = camelifyFieldNames(parse(exampleJson)).extract[BalanceTransaction]
 
-      testBalanceTransaction.id should equal("txn_15DRvX2eZvKYlo2CgxMQ25SQ")
-      testBalanceTransaction.amount should equal(500)
+      testBalanceTransaction.id should equal("txn_17bBwe2eZvKYlo2Cuwcyi9or")
+      testBalanceTransaction.amount should equal(400)
       testBalanceTransaction.currency should equal("usd")
-      testBalanceTransaction.net should equal(455)
+      testBalanceTransaction.net should equal(358)
       testBalanceTransaction.`type` should equal("charge")
-      testBalanceTransaction.created should equal(1419476679)
-      testBalanceTransaction.availableOn should equal(1420070400)
+      testBalanceTransaction.created should equal(1454687788)
+      testBalanceTransaction.availableOn should equal(1455235200)
       testBalanceTransaction.status should equal("pending")
-      testBalanceTransaction.fee should equal(45)
-      testBalanceTransaction.source should equal("ch_15DRvX2eZvKYlo2CzgFB69s3")
-      testBalanceTransaction.description should equal(None)
-      testBalanceTransaction.feeDetails(0).amount should equal(45)
+      testBalanceTransaction.fee should equal(42)
+      testBalanceTransaction.source should equal("ch_17bBwe2eZvKYlo2Crk3VGEG8")
+      testBalanceTransaction.description should equal(Some("Charge for test@example.com"))
+      testBalanceTransaction.feeDetails(0).amount should equal(42)
       testBalanceTransaction.feeDetails(0).currency should equal("usd")
       testBalanceTransaction.feeDetails(0).`type` should equal("stripe_fee")
       testBalanceTransaction.feeDetails(0).description should equal(Some("Stripe processing fees"))

--- a/src/test/scala/me/frmr/stripe/CardSpec.scala
+++ b/src/test/scala/me/frmr/stripe/CardSpec.scala
@@ -15,39 +15,42 @@ class CardSpec extends WordSpec with ShouldMatchers {
     "retrieve correct fields from Stripe's JSON" in {
       val exampleCardJson = """
         {
-          "id": "card_14uxPs2eZvKYlo2CzgxT7pbv",
+          "id": "card_17tOG52eZvKYlo2CfEJFhcJ2",
           "object": "card",
-          "last4": "4242",
-          "brand": "Visa",
-          "funding": "credit",
-          "exp_month": 1,
-          "exp_year": 2050,
-          "fingerprint": "Xt5EWLLDS7FJjR1c",
-          "country": "US",
-          "name": null,
-          "address_line1": null,
-          "address_line2": null,
           "address_city": null,
+          "address_country": null,
+          "address_line1": null,
+          "address_line1_check": null,
+          "address_line2": null,
           "address_state": null,
           "address_zip": null,
-          "address_country": null,
-          "cvc_check": "pass",
-          "address_line1_check": null,
           "address_zip_check": null,
+          "brand": "Visa",
+          "country": "US",
+          "customer": null,
+          "cvc_check": "pass",
           "dynamic_last4": null,
-          "customer": null
+          "exp_month": 11,
+          "exp_year": 2022,
+          "fingerprint": "jfYpjs0oYxBYKc4C",
+          "funding": "credit",
+          "last4": "4242",
+          "metadata": {
+          },
+          "name": "tickle.me.edmo@gmail.com",
+          "tokenization_method": null
         }
       """
 
       val testCard = camelifyFieldNames(parse(exampleCardJson)).extract[Card]
 
-      testCard.id should equal("card_14uxPs2eZvKYlo2CzgxT7pbv")
+      testCard.id should equal("card_17tOG52eZvKYlo2CfEJFhcJ2")
       testCard.last4 should equal("4242")
       testCard.brand should equal("Visa")
       testCard.funding should equal("credit")
-      testCard.expMonth should equal(1)
-      testCard.expYear should equal(2050)
-      testCard.fingerprint should equal("Xt5EWLLDS7FJjR1c")
+      testCard.expMonth should equal(11)
+      testCard.expYear should equal(2022)
+      testCard.fingerprint should equal("jfYpjs0oYxBYKc4C")
       testCard.country.get should equal("US")
       testCard.cvcCheck.get should equal("pass")
     }

--- a/src/test/scala/me/frmr/stripe/ChargeSpec.scala
+++ b/src/test/scala/me/frmr/stripe/ChargeSpec.scala
@@ -15,83 +15,88 @@ class ChargeSpec extends WordSpec with ShouldMatchers {
     "retrieve correct fields from Stripe's JSON" in {
       val exampleChargeJson = """
         {
-          "id": "ch_14uxPs2eZvKYlo2CIDZ45vfW",
+          "id": "ch_17tNoH2eZvKYlo2CBtLgE7Wa",
           "object": "charge",
-          "created": 1415069492,
-          "livemode": false,
-          "paid": true,
-          "amount": 500,
-          "currency": "usd",
-          "refunded": false,
-          "card": {
-            "id": "card_14uxPs2eZvKYlo2CzgxT7pbv",
-            "object": "card",
-            "last4": "4242",
-            "brand": "Visa",
-            "funding": "credit",
-            "exp_month": 1,
-            "exp_year": 2050,
-            "fingerprint": "Xt5EWLLDS7FJjR1c",
-            "country": "US",
-            "name": null,
-            "address_line1": null,
-            "address_line2": null,
-            "address_city": null,
-            "address_state": null,
-            "address_zip": null,
-            "address_country": null,
-            "cvc_check": "pass",
-            "address_line1_check": null,
-            "address_zip_check": null,
-            "dynamic_last4": null,
-            "customer": null
-          },
-          "captured": true,
-          "refunds": {
-            "object": "list",
-            "total_count": 0,
-            "has_more": false,
-            "url": "/v1/charges/ch_14uxPs2eZvKYlo2CIDZ45vfW/refunds",
-            "data": [
-
-            ]
-          },
-          "balance_transaction": "txn_14smii2eZvKYlo2C2XeEZU0O",
-          "failure_message": null,
-          "failure_code": null,
+          "amount": 300,
           "amount_refunded": 0,
-          "customer": null,
-          "invoice": null,
+          "application_fee": null,
+          "balance_transaction": "txn_17bBwe2eZvKYlo2Cuwcyi9or",
+          "captured": true,
+          "created": 1459023301,
+          "currency": "usd",
+          "customer": "cus_7yobPWbyKiMd1K",
           "description": null,
+          "destination": null,
           "dispute": null,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": "in_17tMpm2eZvKYlo2CVXsIe10j",
+          "livemode": false,
           "metadata": {
           },
-          "statement_description": null,
-          "fraud_details": {
-            "stripe_report": null,
-            "user_report": null
-          },
+          "order": null,
+          "paid": true,
           "receipt_email": null,
           "receipt_number": null,
-          "shipping": null
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_17tNoH2eZvKYlo2CBtLgE7Wa/refunds"
+          },
+          "shipping": null,
+          "source": {
+            "id": "card_17iqyX2eZvKYlo2CTS5vgxM4",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": "cus_7yobPWbyKiMd1K",
+            "cvc_check": null,
+            "dynamic_last4": null,
+            "exp_month": 12,
+            "exp_year": 2016,
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": null,
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "status": "succeeded"
         }
       """
 
       val testCharge = camelifyFieldNames(parse(exampleChargeJson)).extract[Charge]
 
-      testCharge.id.get should equal("ch_14uxPs2eZvKYlo2CIDZ45vfW")
-      testCharge.created.get should equal(1415069492)
+      testCharge.id.get should equal("ch_17tNoH2eZvKYlo2CBtLgE7Wa")
+      testCharge.created.get should equal(1459023301)
       testCharge.livemode.get should equal(false)
       testCharge.paid.get should equal(true)
-      testCharge.amount.get should equal(500)
+      testCharge.amount.get should equal(300)
       testCharge.currency.get should equal("usd")
       testCharge.refunded.get should equal(false)
       testCharge.captured.get should equal(true)
-      testCharge.balanceTransaction.get should equal("txn_14smii2eZvKYlo2C2XeEZU0O")
+      testCharge.balanceTransaction.get should equal("txn_17bBwe2eZvKYlo2Cuwcyi9or")
       testCharge.failureMessage should equal(None)
       testCharge.failureCode should equal(None)
       testCharge.amountRefunded.get should equal(0)
-      testCharge.customer should equal(None)
+      testCharge.customer should equal(Some("cus_7yobPWbyKiMd1K"))
     }
   }
 }

--- a/src/test/scala/me/frmr/stripe/CustomerSpec.scala
+++ b/src/test/scala/me/frmr/stripe/CustomerSpec.scala
@@ -15,73 +15,77 @@ class CustomerSpec extends WordSpec with ShouldMatchers {
     "retrieve correct fields from Stripe's JSON" in {
       val exampleCustomerJson = """
         {
+          "id": "cus_89c8SrPpHZP4ex",
           "object": "customer",
-          "created": 1414861702,
-          "id": "cus_54DocayG4yRrNK",
-          "livemode": false,
-          "description": "nkajok@coolfiresolutions.com",
-          "email": null,
+          "account_balance": 0,
+          "created": 1459004472,
+          "currency": "usd",
+          "default_source": "card_17tIuV2eZvKYlo2Cf2npn5PC",
           "delinquent": false,
+          "description": "Customer for test@example.com",
+          "discount": null,
+          "email": "y@ymail.com",
+          "livemode": false,
           "metadata": {
+          },
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+            {
+              "id": "card_17tIuV2eZvKYlo2Cf2npn5PC",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": "cus_89c8SrPpHZP4ex",
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 1,
+              "exp_year": 2019,
+              "fingerprint": "Xt5EWLLDS7FJjR1c",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "y@ymail.com",
+              "tokenization_method": null
+            }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_89c8SrPpHZP4ex/sources"
           },
           "subscriptions": {
             "object": "list",
-            "total_count": 0,
-            "has_more": false,
-            "url": "/v1/customers/cus_54DocayG4yRrNK/subscriptions",
             "data": [
 
-            ]
-          },
-          "discount": null,
-          "account_balance": 0,
-          "currency": "usd",
-          "cards": {
-            "object": "list",
-            "total_count": 1,
+            ],
             "has_more": false,
-            "url": "/v1/customers/cus_54DocayG4yRrNK/cards",
-            "data": [
-              {
-                "id": "card_14u5MP2eZvKYlo2CIukHVUb4",
-                "object": "card",
-                "last4": "4242",
-                "brand": "Visa",
-                "funding": "credit",
-                "exp_month": 12,
-                "exp_year": 2014,
-                "fingerprint": "Xt5EWLLDS7FJjR1c",
-                "country": "US",
-                "name": null,
-                "address_line1": null,
-                "address_line2": null,
-                "address_city": null,
-                "address_state": null,
-                "address_zip": null,
-                "address_country": null,
-                "cvc_check": "pass",
-                "address_line1_check": null,
-                "address_zip_check": null,
-                "dynamic_last4": null,
-                "customer": "cus_54DocayG4yRrNK"
-              }
-            ]
-          },
-          "default_card": "card_14u5MP2eZvKYlo2CIukHVUb4"
+            "total_count": 0,
+            "url": "/v1/customers/cus_89c8SrPpHZP4ex/subscriptions"
+          }
         }
       """
 
       val testCustomer = camelifyFieldNames(parse(exampleCustomerJson)).extract[Customer]
 
-      testCustomer.id should equal("cus_54DocayG4yRrNK")
+      testCustomer.id should equal("cus_89c8SrPpHZP4ex")
       testCustomer.livemode should equal(false)
-      testCustomer.created should equal(1414861702)
+      testCustomer.created should equal(1459004472)
       testCustomer.accountBalance should equal(0)
       testCustomer.currency should equal("usd")
-      testCustomer.defaultCard.get should equal("card_14u5MP2eZvKYlo2CIukHVUb4")
+      testCustomer.defaultSource.get should equal("card_17tIuV2eZvKYlo2Cf2npn5PC")
       testCustomer.delinquent should equal(false)
-      testCustomer.description.get should equal("nkajok@coolfiresolutions.com")
-      testCustomer.email should equal(None)
+      testCustomer.description.get should equal("Customer for test@example.com")
+      testCustomer.email should equal(Some("y@ymail.com"))
       testCustomer.metadata should equal(Map.empty)
       testCustomer.discount should equal(None)
     }

--- a/src/test/scala/me/frmr/stripe/EventSpec.scala
+++ b/src/test/scala/me/frmr/stripe/EventSpec.scala
@@ -15,87 +15,67 @@ class EventSpec extends WordSpec with ShouldMatchers {
     "retrieve correct fiels from Stripe's JSON" in {
       val exampleEventJson = """
         {
-          "id": "evt_15FuBx2eZvKYlo2CWUhJSwAA",
-          "created": 1420061985,
-          "livemode": false,
-          "type": "charge.succeeded",
+          "id": "evt_17tOU02eZvKYlo2C6jfLWVct",
+          "object": "event",
+          "api_version": "2016-03-07",
+          "created": 1459025888,
           "data": {
             "object": {
-              "id": "ch_15FuBx2eZvKYlo2CCvbr8nhA",
-              "object": "charge",
-              "created": 1420061985,
-              "livemode": false,
-              "paid": true,
-              "amount": 100,
-              "currency": "usd",
-              "refunded": false,
-              "captured": true,
-              "card": {
-                "id": "card_15FuBu2eZvKYlo2CuP3VJSLl",
-                "object": "card",
-                "last4": "4242",
-                "brand": "Visa",
-                "funding": "credit",
-                "exp_month": 12,
-                "exp_year": 2016,
-                "fingerprint": "Xt5EWLLDS7FJjR1c",
-                "country": "US",
-                "name": "sbvmqa+606060@gmail.com",
-                "address_line1": null,
-                "address_line2": null,
-                "address_city": null,
-                "address_state": null,
-                "address_zip": null,
-                "address_country": null,
-                "cvc_check": null,
-                "address_line1_check": null,
-                "address_zip_check": null,
-                "dynamic_last4": null,
-                "customer": "cus_5QljAQau5W1doA"
-              },
-              "balance_transaction": "txn_15FuBx2eZvKYlo2CK1g4gLF9",
-              "failure_message": null,
-              "failure_code": null,
-              "amount_refunded": 0,
-              "customer": "cus_5QljAQau5W1doA",
-              "invoice": null,
-              "description": "Charge for VirtuMedix consultation",
-              "dispute": null,
+              "id": "sub_7way2VPy8fnbjp",
+              "object": "subscription",
+              "application_fee_percent": null,
+              "cancel_at_period_end": false,
+              "canceled_at": null,
+              "current_period_end": 1459630606,
+              "current_period_start": 1459025806,
+              "customer": "cus_7walp6daH6Hrns",
+              "discount": null,
+              "ended_at": null,
               "metadata": {
               },
-              "statement_descriptor": null,
-              "fraud_details": {
+              "plan": {
+                "id": "$555.55_subsplan10",
+                "object": "plan",
+                "amount": 55555,
+                "created": 1456001805,
+                "currency": "usd",
+                "interval": "week",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {
+                },
+                "name": "$555.55 Subscription Plan For Joe Aliling_24",
+                "statement_descriptor": null,
+                "trial_period_days": null
               },
-              "receipt_email": null,
-              "receipt_number": null,
-              "shipping": null,
-              "refunds": {
-                "object": "list",
-                "total_count": 0,
-                "has_more": false,
-                "url": "/v1/charges/ch_15FuBx2eZvKYlo2CCvbr8nhA/refunds",
-                "data": [
-
-                ]
-              }
+              "quantity": 1,
+              "start": 1456001806,
+              "status": "active",
+              "tax_percent": null,
+              "trial_end": null,
+              "trial_start": null
+            },
+            "previous_attributes": {
+              "current_period_end": 1459025806,
+              "current_period_start": 1458421006
             }
           },
-          "object": "event",
+          "livemode": false,
           "pending_webhooks": 0,
-          "request": "iar_5QljgdiWAB2fxv",
-          "api_version": "2014-12-22"
+          "request": null,
+          "type": "customer.subscription.updated"
         }
       """
 
       val exampleEvent = camelifyFieldNames(parse(exampleEventJson)).extract[Event]
 
-      exampleEvent.id should equal("evt_15FuBx2eZvKYlo2CWUhJSwAA")
-      exampleEvent.created should equal(1420061985)
+      exampleEvent.id should equal("evt_17tOU02eZvKYlo2C6jfLWVct")
+      exampleEvent.created should equal(1459025888)
       exampleEvent.livemode should equal(false)
-      exampleEvent.`type` should equal("charge.succeeded")
+      exampleEvent.`type` should equal("customer.subscription.updated")
       exampleEvent.pendingWebhooks should equal(0)
-      exampleEvent.request should equal("iar_5QljgdiWAB2fxv")
-      exampleEvent.apiVersion should equal("2014-12-22")
+      exampleEvent.request should equal(null)
+      exampleEvent.apiVersion should equal("2016-03-07")
     }
   }
 }

--- a/src/test/scala/me/frmr/stripe/PlanSpec.scala
+++ b/src/test/scala/me/frmr/stripe/PlanSpec.scala
@@ -15,30 +15,30 @@ class PlanSpec extends WordSpec with ShouldMatchers {
     "retrieve correct fields from Stripe's JSON" in {
       val examplePlanJson = """
         {
-          "interval": "month",
-          "name": "AAAAplanname",
-          "created": 1412299176,
-          "amount": 2000,
-          "currency": "usd",
-          "id": "-JYI_nRwd_ltcGRLnVys",
+          "id": "gold2132",
           "object": "plan",
-          "livemode": false,
+          "amount": 2000,
+          "created": 1386249594,
+          "currency": "usd",
+          "interval": "month",
           "interval_count": 1,
-          "trial_period_days": null,
+          "livemode": false,
           "metadata": {
           },
-          "statement_descriptor": null
+          "name": "Gold ",
+          "statement_descriptor": null,
+          "trial_period_days": null
         }
       """
 
       val testPlan = camelifyFieldNames(parse(examplePlanJson)).extract[Plan]
 
       testPlan.interval should equal("month")
-      testPlan.name should equal("AAAAplanname")
-      testPlan.created should equal(1412299176)
+      testPlan.name should equal("Gold ")
+      testPlan.created should equal(1386249594)
       testPlan.amount should equal(2000)
       testPlan.currency should equal("usd")
-      testPlan.id should equal("-JYI_nRwd_ltcGRLnVys")
+      testPlan.id should equal("gold2132")
       testPlan.livemode should equal(false)
       testPlan.intervalCount should equal(1)
       testPlan.trialPeriodDays should equal(None)

--- a/src/test/scala/me/frmr/stripe/SubscriptionSpec.scala
+++ b/src/test/scala/me/frmr/stripe/SubscriptionSpec.scala
@@ -15,50 +15,51 @@ class SubscriptionSpec extends WordSpec with ShouldMatchers {
     "retrieve correct fields from Stripe's JSON" in {
       val exampleSubscriptionJson = """
         {
-          "id": "sub_56Eev7i0d0N9Dx",
+          "id": "sub_89hyIohmkV31Ew",
+          "object": "subscription",
+          "application_fee_percent": null,
+          "cancel_at_period_end": false,
+          "canceled_at": null,
+          "current_period_end": 1461704593,
+          "current_period_start": 1459026193,
+          "customer": "cus_89c8SrPpHZP4ex",
+          "discount": null,
+          "ended_at": null,
+          "metadata": {
+          },
           "plan": {
-            "interval": "month",
-            "name": "-JYI_nRwd_ltcGRLnVys",
-            "created": 1412299176,
-            "amount": 2000,
-            "currency": "usd",
-            "id": "-JYI_nRwd_ltcGRLnVys",
+            "id": "gold2132",
             "object": "plan",
-            "livemode": false,
+            "amount": 2000,
+            "created": 1386249594,
+            "currency": "usd",
+            "interval": "month",
             "interval_count": 1,
-            "trial_period_days": null,
+            "livemode": false,
             "metadata": {
             },
-            "statement_description": null
+            "name": "Gold ",
+            "statement_descriptor": null,
+            "trial_period_days": null
           },
-          "object": "subscription",
-          "start": 1415326152,
-          "status": "active",
-          "customer": "cus_56ENenCV0GVVQ6",
-          "cancel_at_period_end": false,
-          "current_period_start": 1415326152,
-          "current_period_end": 1417918152,
-          "ended_at": null,
-          "trial_start": null,
-          "trial_end": null,
-          "canceled_at": null,
           "quantity": 1,
-          "application_fee_percent": null,
-          "discount": null,
-          "metadata": {
-          }
+          "start": 1459026193,
+          "status": "active",
+          "tax_percent": null,
+          "trial_end": null,
+          "trial_start": null
         }
       """
 
       val testSubscription = camelifyFieldNames(parse(exampleSubscriptionJson)).extract[Subscription]
 
-      testSubscription.id should equal(Some("sub_56Eev7i0d0N9Dx"))
-      testSubscription.start should equal(Some(1415326152))
+      testSubscription.id should equal(Some("sub_89hyIohmkV31Ew"))
+      testSubscription.start should equal(Some(1459026193))
       testSubscription.status should equal(Some("active"))
-      testSubscription.customer should equal(Some("cus_56ENenCV0GVVQ6"))
+      testSubscription.customer should equal(Some("cus_89c8SrPpHZP4ex"))
       testSubscription.cancelAtPeriodEnd should equal(Some(false))
-      testSubscription.currentPeriodStart should equal(Some(1415326152))
-      testSubscription.currentPeriodEnd should equal(Some(1417918152))
+      testSubscription.currentPeriodStart should equal(Some(1459026193))
+      testSubscription.currentPeriodEnd should equal(Some(1461704593))
       testSubscription.endedAt should equal(None)
       testSubscription.trialStart should equal(None)
       testSubscription.trialEnd should equal(None)

--- a/src/test/scala/me/frmr/stripe/TokenSpec.scala
+++ b/src/test/scala/me/frmr/stripe/TokenSpec.scala
@@ -15,42 +15,45 @@ class TokenSpec extends WordSpec with ShouldMatchers {
     "retrieve correct fields from Stripe's JSON" in {
       val exampleTokenJson = """
         {
-          "id": "tok_15Fd2I2eZvKYlo2CnJvoo1FX",
-          "livemode": false,
-          "created": 1419996038,
-          "used": false,
+          "id": "tok_17szAe2eZvKYlo2Ch8eMPKHH",
           "object": "token",
-          "type": "card",
           "card": {
-            "id": "card_15Fd2I2eZvKYlo2CKcSU943C",
+            "id": "card_17szAe2eZvKYlo2Cg5FDnNgj",
             "object": "card",
-            "last4": "4242",
-            "brand": "Visa",
-            "funding": "credit",
-            "exp_month": 8,
-            "exp_year": 2015,
-            "fingerprint": "Xt5EWLLDS7FJjR1c",
-            "country": "US",
-            "name": null,
-            "address_line1": null,
-            "address_line2": null,
             "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
             "address_state": null,
             "address_zip": null,
-            "address_country": null,
-            "cvc_check": null,
-            "address_line1_check": null,
             "address_zip_check": null,
-            "dynamic_last4": null
-          }
+            "brand": "Visa",
+            "country": "US",
+            "cvc_check": null,
+            "dynamic_last4": null,
+            "exp_month": 8,
+            "exp_year": 2017,
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": null,
+            "tokenization_method": null
+          },
+          "client_ip": null,
+          "created": 1458928588,
+          "livemode": false,
+          "type": "card",
+          "used": false
         }
       """
 
       val testToken = camelifyFieldNames(parse(exampleTokenJson)).extract[Token]
 
-      testToken.id should equal("tok_15Fd2I2eZvKYlo2CnJvoo1FX")
+      testToken.id should equal("tok_17szAe2eZvKYlo2Ch8eMPKHH")
       testToken.livemode should equal(false)
-      testToken.created should equal(1419996038)
+      testToken.created should equal(1458928588)
       testToken.used should equal(false)
       testToken.`type` should equal("card")
     }


### PR DESCRIPTION
![](http://i.imgur.com/tJFOu9i.gif)

Updated the api version to `2016-03-07` and ensures tests pass with new json test data that correlates to the API version.

Changes that were required: 

* A `Customer` has `sources` not `cards` now. Yay bit coin <_<
* `Account` object no longer contains `currenciesSupported`. Thats been broken out into a diff object. The new object was not added though.
* Bump in `Lift` and `Scala` as well as some minor bumps for other dependencies. 