### PR TITLE
Allow for Upcoming Invoice to not use `Id`

### DIFF
--- a/src/main/scala/me/frmr/stripe/Invoice.scala
+++ b/src/main/scala/me/frmr/stripe/Invoice.scala
@@ -25,6 +25,39 @@ case class InvoiceLineItem(
   metadata: Map[String, String]
 )
 
+trait BaseInvoice {
+  def livemode: Boolean
+  def amountDue: Long
+  def attemptCount: Int
+  def attempted: Boolean
+  def closed: Boolean
+  def currency: String
+  def customer: String
+  def date: Long
+  def forgiven: Boolean
+  def lines: InvoiceLineItemList
+  def paid: Boolean
+  def periodEnd: Long
+  def periodStart: Long
+  def startingBalance: Long
+  def subtotal: Long
+  def total: Long
+  def applicationFee: Option[Long]
+  def charge: String
+  def description: Option[String]
+  def discount: Option[Discount]
+  def endingBalance: Long
+  def nextPaymentAttempt: Option[Long]
+  def receiptNumber: Option[String]
+  def statementDescriptor: String
+  def subscription: Option[String]
+  def webhooksDeliveredAt: Long
+  def tax: Long
+  def taxPercent: Option[Double]
+  def metadata: Map[String, String]
+  def raw: Option[JValue] = None
+}
+
 case class Invoice(
   id: String,
   livemode: Boolean,
@@ -56,8 +89,43 @@ case class Invoice(
   tax: Long,
   taxPercent: Option[Double],
   metadata: Map[String, String],
-  raw: Option[JValue] = None
-) extends StripeObject {
+  override val raw: Option[JValue] = None
+) extends StripeObject with BaseInvoice {
+  def withRaw(raw: JValue) = this.copy(raw = Some(raw))
+}
+
+case class UpcomingInvoice(
+  livemode: Boolean,
+  amountDue: Long,
+  attemptCount: Int,
+  attempted: Boolean,
+  closed: Boolean,
+  currency: String,
+  customer: String,
+  date: Long,
+  forgiven: Boolean,
+  lines: InvoiceLineItemList,
+  paid: Boolean,
+  periodEnd: Long,
+  periodStart: Long,
+  startingBalance: Long,
+  subtotal: Long,
+  total: Long,
+  applicationFee: Option[Long],
+  charge: String,
+  description: Option[String],
+  discount: Option[Discount],
+  endingBalance: Long,
+  nextPaymentAttempt: Option[Long],
+  receiptNumber: Option[String],
+  statementDescriptor: String,
+  subscription: Option[String],
+  webhooksDeliveredAt: Long,
+  tax: Long,
+  taxPercent: Option[Double],
+  metadata: Map[String, String],
+  override val raw: Option[JValue] = None
+) extends StripeObject with BaseInvoice {
   def withRaw(raw: JValue) = this.copy(raw = Some(raw))
 }
 
@@ -104,7 +172,7 @@ object Invoice extends Listable[InvoiceList] with Gettable[Invoice] {
     val params = requiredParams ++ optionalParams
     val uri = baseResourceCalculator(exec.baseReq) / "upcoming"
 
-    exec.executeFor[Invoice](uri <<? params)
+    exec.executeFor[UpcomingInvoice](uri <<? params)
   }
 
   def update(


### PR DESCRIPTION
`Invoice.getUpcoming` fails due to lack of `id` on the upcoming invoice. This introduces a `BaseInvoice` class to handle both cases.

Doesnt work quite yet.